### PR TITLE
Correct backtrace ordering by indexing from 1

### DIFF
--- a/lib/backtrace.ml
+++ b/lib/backtrace.ml
@@ -51,7 +51,7 @@ let to_string_hum xs =
     Buffer.add_string results (Printf.sprintf "%d/%d %s %s file %s, line %d" i xs' x.process (if first_line then "Raised at" else "Called from") x.filename x.line);
     Buffer.add_string results "\n";
     loop false (i + 1) xs in
-  loop true 0 xs
+  loop true 1 xs
 
 type table = {
   backtraces: t array;


### PR DESCRIPTION
All backtraces have been off by one...

0/9 xapi @ renoir Raised at file "db_rpc_client_v1.ml", line 33, characters 14-39
...
8/9 xapi @ renoir Called from file "lib/backtrace.ml", line 150, characters 17-21

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>