### PR TITLE
xapi-backtrace: add support for ppx_sexp_conv.v0.11.0

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -8,7 +8,7 @@ let flags = function
     List.fold_left (fun acc pkg -> acc ^ " -package " ^ pkg) "" pkgs
   ) in
   let ic = Unix.open_process_in
-    (cmd ^ " | grep -oEe '-ppx (\"([^\"\\]|\\.)+\"|\w+)'")
+    (cmd ^ " | grep -oEe '-ppx (\"([^\"\\]|\\.)+\"|\\w+)'")
   in
   let rec go ic acc =
     try go ic (acc ^ " " ^ input_line ic) with End_of_file -> close_in ic; acc
@@ -24,7 +24,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
  ((name backtrace)
   (public_name xapi-backtrace)
   (libraries (ppx_deriving_rpc
-              ppx_sexp_conv
+              ppx_sexp_conv.runtime-lib
               rpclib
               rpclib.json
               threads


### PR DESCRIPTION
Can be released with or after https://github.com/xapi-project/xs-opam/pull/268 is merged

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>