### PR TITLE
jbuild: remove ppx_deriving_rpc from libraries

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -23,8 +23,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (library
  ((name backtrace)
   (public_name xapi-backtrace)
-  (libraries (ppx_deriving_rpc
-              ppx_sexp_conv.runtime-lib
+  (libraries (ppx_sexp_conv.runtime-lib
               rpclib
               rpclib.json
               threads


### PR DESCRIPTION
It should only be used as a rewriter