### PR TITLE
Simplify jbuild, quiet warnings

### DIFF
--- a/lib/backtrace.ml
+++ b/lib/backtrace.ml
@@ -11,7 +11,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *)
-open Sexplib.Std
+open Sexplib0.Sexp_conv
 
 let my_name = ref (Filename.basename Sys.argv.(0))
 let set_my_name x = my_name := x

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -1,33 +1,9 @@
-(* -*- tuareg -*- *)
-#require "unix"
-
-let flags = function
-| [] -> ""
-| pkgs ->
-  let cmd = "ocamlfind ocamlc -verbose" ^ (
-    List.fold_left (fun acc pkg -> acc ^ " -package " ^ pkg) "" pkgs
-  ) in
-  let ic = Unix.open_process_in
-    (cmd ^ " | grep -oEe '-ppx (\"([^\"\\]|\\.)+\"|\\w+)'")
-  in
-  let rec go ic acc =
-    try go ic (acc ^ " " ^ input_line ic) with End_of_file -> close_in ic; acc
-  in
-  go ic ""
-
-let rewriters = ["ppx_deriving_rpc"; "ppx_sexp_conv"]
-
-let () = Printf.ksprintf Jbuild_plugin.V1.send {|
 (jbuild_version 1)
 
 (library
  ((name backtrace)
   (public_name xapi-backtrace)
-  (libraries (ppx_sexp_conv.runtime-lib
-              rpclib
-              rpclib.json
-              threads
-              sexplib))
-  (flags (:standard %s))
- ))
-|} (flags rewriters)
+  (flags (:standard -w -39-32))
+  (libraries
+   (ppx_sexp_conv.runtime-lib rpclib rpclib.json threads sexplib))
+  (preprocess (pps (ppx_deriving_rpc ppx_sexp_conv)))))

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -5,5 +5,5 @@
   (public_name xapi-backtrace)
   (flags (:standard -w -39-32))
   (libraries
-   (ppx_sexp_conv.runtime-lib rpclib rpclib.json threads sexplib))
+   (rpclib rpclib.json threads))
   (preprocess (pps (ppx_deriving_rpc ppx_sexp_conv)))))

--- a/xapi-backtrace.opam
+++ b/xapi-backtrace.opam
@@ -11,7 +11,6 @@ build: ["jbuilder" "build" "-p" name "-j" jobs]
 depends: [
   "jbuilder" {build}
   "base-threads"
-  "sexplib"
   "ppx_sexp_conv" {>= "v0.11.0"}
   "rpc" {>= "1.9.51"}
 ]


### PR DESCRIPTION
* take advantage for PPX rewriting in jbuild file
* remove warnings caused by PPX code

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>